### PR TITLE
chore: add api_shortname and library_type to repo metadata

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "client_documentation": "https://cloud.google.com/nodejs/docs/reference/dataproc-metastore/latest",
   "api_id": "metastore.googleapis.com",
   "distribution_name": "@google-cloud/dataproc-metastore",
-  "release_level": "BETA",
+  "release_level": "preview",
   "default_version": "v1",
   "language": "nodejs",
   "name_pretty": "Dataproc Metastore",
@@ -10,5 +10,7 @@
   "product_documentation": "https://cloud.google.com/dataproc-metastore/",
   "requires_billing": true,
   "name": "metastore",
-  "issue_tracker": "https://github.com/googleapis/nodejs-dataproc-metastore/issues"
+  "issue_tracker": "https://github.com/googleapis/nodejs-dataproc-metastore/issues",
+  "api_shortname": "metastore",
+  "library_type": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -12,5 +12,5 @@
   "name": "metastore",
   "issue_tracker": "https://github.com/googleapis/nodejs-dataproc-metastore/issues",
   "api_shortname": "metastore",
-  "library_type": ""
+  "library_type": "GAPIC_AUTO"
 }

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ This library follows [Semantic Versioning](http://semver.org/).
 
 
 
+This library is considered to be in **preview**. This means it is still a
+work-in-progress and under active development. Any release is subject to
+backwards-incompatible changes at any time.
+
 
 More Information: [Google Cloud Platform Launch Stages][launch_stages]
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # [Dataproc Metastore: Node.js Client](https://github.com/googleapis/nodejs-dataproc-metastore)
 
-[![release level](https://img.shields.io/badge/release%20level-beta-yellow.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+
 [![npm version](https://img.shields.io/npm/v/@google-cloud/dataproc-metastore.svg)](https://www.npmjs.org/package/@google-cloud/dataproc-metastore)
 [![codecov](https://img.shields.io/codecov/c/github/googleapis/nodejs-dataproc-metastore/main.svg?style=flat)](https://codecov.io/gh/googleapis/nodejs-dataproc-metastore)
 


### PR DESCRIPTION
Update .repo-metadata.json as required by go/library-data-integrity 